### PR TITLE
Npt bug fixes

### DIFF
--- a/PERFTEST.PS1
+++ b/PERFTEST.PS1
@@ -3,8 +3,9 @@
 #===============================================
 Param(
     [parameter(Mandatory=$false)] [switch] $Detail = $false,
-    [parameter(Mandatory=$false)] [switch] $Diag   = $false,    
+    [parameter(Mandatory=$false)] [switch] $Diag   = $false,
     [parameter(Mandatory=$false)] [Int]    $Iterations = 1,
+    [parameter(Mandatory=$false)] [ValidateSet('Sampling','Testing')] [string] $Config = "Sampling",
     [parameter(Mandatory=$true)]  [string] $DestIp,
     [parameter(Mandatory=$true)]  [string] $SrcIp,
     [parameter(Mandatory=$true)]  [ValidateScript({Test-Path $_ -PathType Container})] [String] $OutDir = "" 
@@ -20,6 +21,7 @@ function input_display {
     Write-Host "  -Detail     = $Detail"
     Write-Host "  -Diag       = $Diag"
     Write-Host "  -Iterations = $Iterations"
+    Write-Host "  -Config     = $Config"
     Write-Host "  -DestIp     = $DestIp"
     Write-Host "  -SrcIp      = $SrcIp"
     Write-Host "  -OutDir     = $OutDir"
@@ -83,6 +85,7 @@ function test_main {
         [parameter(Mandatory=$false)] [switch] $Detail     = $false,
         [parameter(Mandatory=$false)] [switch] $Diag       = $false,
         [parameter(Mandatory=$false)] [Int]    $Iterations = 1,
+        [parameter(Mandatory=$false)] [ValidateSet('Sampling','Testing')] [string] $Config = "Sampling",
         [parameter(Mandatory=$true)]  [string] $DestIp,
         [parameter(Mandatory=$true)]  [string] $SrcIp,
         [parameter(Mandatory=$true)]  [ValidateScript({Test-Path $_ -PathType Container})] [String] $OutDir = "" 
@@ -91,7 +94,7 @@ function test_main {
     input_display
 
     $start   = Get-Date
-    $version = "2020.08.14.0" # Version within date context
+    $version = "2020.08.16.0" # Version within date context
 
     Write-Host $start
     Write-Host $version
@@ -99,6 +102,7 @@ function test_main {
     [int]    $g_iters     = $Iterations
     [bool]   $g_detail    = $Detail
     [bool]   $g_diag      = $Diag
+    [string] $g_config    = $Config
     [string] $g_DestIp    = $DestIp
     [string] $g_SrcIp     = $SrcIp
 
@@ -114,7 +118,7 @@ function test_main {
         #.\diag\Network.Diagnosis.ps1 -DestIp $g_DestIp -SrcIp $g_SrcIp -OutDir $workDir
     }else {
         .\latte\latte.TESTGEN.ps1   -DestIp $g_DestIp -SrcIp $g_SrcIp -OutDir $workDir -Detail:$g_detail -Iterations $g_iters
-        .\ntttcp\ntttcp.TESTGEN.ps1 -DestIp $g_DestIp -SrcIp $g_SrcIp -OutDir $workDir -Detail:$g_detail -Iterations $g_iters
+        .\ntttcp\ntttcp.TESTGEN.ps1 -DestIp $g_DestIp -SrcIp $g_SrcIp -OutDir $workDir -Detail:$g_detail -Iterations $g_iters -Config $g_config
     }
 } test_main @PSBoundParameters # Entry Point
 

--- a/latte/latte.TESTGEN.ps1
+++ b/latte/latte.TESTGEN.ps1
@@ -55,15 +55,22 @@ function test_send {
         [parameter(Mandatory=$true)]   [String] $Snd,
         [parameter(Mandatory=$false)]  [String] $Options,
         [parameter(Mandatory=$true)]   [String] $OutDir,
-        [parameter(Mandatory=$true)]   [String] $Fname
+        [parameter(Mandatory=$true)]   [String] $Fname,
+        [parameter(Mandatory=$false)]  [bool]   $NoDumpParam = $false
     )
 
-    [int] $msgbytes = 4
-    [int] $rangeus  = 10
-    [int] $rangemax = 98
+    [int] $msgbytes      = 4
+    [int] $rangeus       = 10
+    [int] $rangemax      = 98
 
-    [string] $out = (Join-Path -Path $OutDir -ChildPath "$Fname")
-    [string] $cmd = "latte.exe -sa -c -a $g_DestIp" + ":"  + "$Port $Iter -hist -hc $rangemax -hl $rangeus $Type -snd $snd $Options -so -dump $out.data.txt > $out.txt"
+    [string] $out        = (Join-Path -Path $OutDir -ChildPath "$Fname")
+    [string] $dumpOption = "-dump $out.data.txt"
+
+    if ($NoDumpParam) {
+        $dumpOption = ""
+    }
+
+    [string] $cmd = "latte.exe -sa -c -a $g_DestIp" + ":"  + "$Port $Iter -hist -hc $rangemax -hl $rangeus $Type -snd $snd $Options -so $dumpOption > $out.txt"
     Write-Output $cmd | Out-File -Encoding ascii -Append $g_log
     Write-Output $cmd | Out-File -Encoding ascii -Append $g_logSend
     Write-Host   $cmd 
@@ -130,12 +137,12 @@ function test_latte_generate {
             foreach ($snd in $snds) {
                 for ($i=0; $i -lt $g_iters; $i++) {
                     # Default
-                    test_send -Iter "-t $sec" -Port ($tmp+$i) -Type "-$soc" -Snd $snd -OutDir $dir -Fname "$soc.t$sec.$snd.iter$i"
+                    test_send -Iter "-t $sec" -Port ($tmp+$i) -Type "-$soc" -Snd $snd -OutDir $dir -Fname "$soc.t$sec.$snd.iter$i" -NoDumpParam $true
                     test_recv
                     Write-Host " "
 
                     # Optimized
-                    test_send -Iter "-t $sec" -Port ($tmp+$i) -Type "-$soc" -Snd $snd -Options "-group 0 -rio -riopoll 100000000000" -OutDir $dir -Fname "$soc.t$sec.$snd.OPT.iter$i"
+                    test_send -Iter "-t $sec" -Port ($tmp+$i) -Type "-$soc" -Snd $snd -Options "-group 0 -rio -riopoll 100000000000" -OutDir $dir -Fname "$soc.t$sec.$snd.OPT.iter$i" -NoDumpParam $true
                     test_recv
                     Write-Host " "
                 }

--- a/ntttcp/ntttcp.Sampling.Config.ps1
+++ b/ntttcp/ntttcp.Sampling.Config.ps1
@@ -1,0 +1,2 @@
+$g_runtime = 10
+$g_ptime   = 2

--- a/ntttcp/ntttcp.TESTGEN.ps1
+++ b/ntttcp/ntttcp.TESTGEN.ps1
@@ -4,6 +4,7 @@
 Param(
     [parameter(Mandatory=$false)] [switch] $Detail = $false,
     [parameter(Mandatory=$false)] [Int]    $Iterations = 1,
+    [parameter(Mandatory=$false)] [ValidateSet('Sampling','Testing')] [string] $Config = "Sampling",
     [parameter(Mandatory=$true)]  [string] $DestIp,
     [parameter(Mandatory=$true)]  [string] $SrcIp,
     [parameter(Mandatory=$true)]  [ValidateScript({Test-Path $_ -PathType Container})] [String] $OutDir = "" 
@@ -18,6 +19,7 @@ function input_display {
     Write-Host " Inputs:"
     Write-Host "  -Detail     = $Detail"
     Write-Host "  -Iterations = $Iterations"
+    Write-Host "  -Config     = $Config"
     Write-Host "  -DestIp     = $DestIp"
     Write-Host "  -SrcIp      = $SrcIp"
     Write-Host "  -OutDir     = $OutDir"
@@ -120,12 +122,24 @@ function banner {
 function test_ntttcp {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $OutDir
+        [parameter(Mandatory=$true)] [String] $OutDir,
+        [parameter(Mandatory=$true)] [ValidateScript({Test-Path $_})] [String] $ConfigFile
     )
 
+    #Load the variables needed to generate the commands
     # execution time in seconds
     [int] $g_runtime = 10
     [int] $g_ptime   = 2
+
+    # execution time ($g_runtime) in seconds, wu, cd times ($g_ptime) will come from the Config ps1 file, if specified and take precedence over defaults 
+    Try
+    {
+        . .\$ConfigFile
+    }
+    Catch
+    {
+        Write-Host "$ConfigFile will not be used. Exception $($_.Exception.Message) in $($MyInvocation.MyCommand.Name)"
+    }
 
     # NTTTCP ^2 connection scaling to MAX supported.
     [int]   $ConnMax  = 128 # NTTTCP maximum connections is 999.
@@ -160,24 +174,28 @@ function test_main {
     Param(
         [parameter(Mandatory=$false)] [switch] $Detail = $false,
         [parameter(Mandatory=$false)] [Int]    $Iterations = 1,
+        [parameter(Mandatory=$false)] [ValidateSet('Sampling','Testing')] [string] $Config = "Sampling",
         [parameter(Mandatory=$true)]  [string] $DestIp,
         [parameter(Mandatory=$true)]  [string] $SrcIp,
         [parameter(Mandatory=$true)]  [ValidateScript({Test-Path $_ -PathType Container})] [String] $OutDir = "" 
     )
     input_display
 
-    [int]    $g_iters   = $Iterations
-    [bool]   $g_detail  = $Detail
-    [string] $g_DestIp  = $DestIp.Trim()
-    [string] $g_SrcIp   = $SrcIp.Trim()
-    [string] $dir       = (Join-Path -Path $OutDir -ChildPath "ntttcp") 
-    [string] $g_log     = "$dir\NTTTCP.Commands.txt"
-    [string] $g_logSend = "$dir\NTTTCP.Commands.Send.txt"
-    [string] $g_logRecv = "$dir\NTTTCP.Commands.Recv.txt"
+    [int]    $g_iters      = $Iterations
+    [bool]   $g_detail     = $Detail
+    [string] $g_DestIp     = $DestIp.Trim()
+    [string] $g_SrcIp      = $SrcIp.Trim()
+    [string] $dir          = (Join-Path -Path $OutDir -ChildPath "ntttcp") 
+    [string] $g_log        = "$dir\NTTTCP.Commands.txt"
+    [string] $g_logSend    = "$dir\NTTTCP.Commands.Send.txt"
+    [string] $g_logRecv    = "$dir\NTTTCP.Commands.Recv.txt"
+    [string] $g_ConfigFile = ".\ntttcp\NTTTCP.$Config.Config.ps1"
 
     # Edit spaces in path for Invoke-Expression compatibility
     $dir = $dir -replace ' ','` '
     
     New-Item -ItemType directory -Path $dir | Out-Null
-    test_ntttcp -OutDir $dir
+    Write-Host "test_ntttcp -OutDir $dir -ConfigFile $g_ConfigFile"
+
+    test_ntttcp -OutDir $dir -ConfigFile $g_ConfigFile
 } test_main @PSBoundParameters # Entry Point

--- a/ntttcp/ntttcp.Testing.Config.ps1
+++ b/ntttcp/ntttcp.Testing.Config.ps1
@@ -1,0 +1,2 @@
+ $g_runtime = 300
+ $g_ptime   = 10


### PR DESCRIPTION
Adding support to generate [ntttcp] commands for multiple configurations - ex: generating commands for sampling (default)) or for testing + CR Comments addressed

Fixing bug with latte command generation (where -dump cannot be specified for time based tests)

@omarcardona @cmaloney-msft