### PR TITLE
Bug fixes and runtime adjustments 

### DIFF
--- a/ntttcp/ntttcp.TESTGEN.ps1
+++ b/ntttcp/ntttcp.TESTGEN.ps1
@@ -93,10 +93,10 @@ function test_tcp {
     # NTTTCP outstanding IO ^2 scaling. Min -> Default (2) -> MAX supported.
     # - Finds optimial outstanding IO scaling value per BW
     [int[]] $OutIoList  = @(2, 16) #default is 2, see ntttcp -help
-    [int[]] $BufLenList = @(64)    #default is 64K, see ntttcp -help
+    [int[]] $BufLenList = @(65536)    #default is 64K, see ntttcp -help
     if ($g_detail) {
         $OutIoList  = @(2, 4, 8, 16, 32, 63) # max is 63, see ntttcp -help
-        $BufLenList = @(4096, 65536, 262144) # Stakeholer requested values
+        $BufLenList = @(4096, 65536, 262144) # Stakeholder requested values
     }
 
     foreach ($BufLen in $BufLenList) {

--- a/ntttcp/ntttcp.Testing.Config.ps1
+++ b/ntttcp/ntttcp.Testing.Config.ps1
@@ -1,2 +1,2 @@
- $g_runtime = 300
- $g_ptime   = 10
+ $g_runtime = 90
+ $g_ptime   = 2

--- a/runPerftool.psm1
+++ b/runPerftool.psm1
@@ -351,8 +351,10 @@ param(
         Invoke-Command -Session $sendPSSession -ScriptBlock $ScriptBlockCreateDirForResults -ArgumentList ($CommandsDir+"\Sender\ntttcp\tcp")
         Invoke-Command -Session $recvPSSession -ScriptBlock $ScriptBlockCreateDirForResults -ArgumentList ($CommandsDir+"\Receiver\ntttcp\udp")
         Invoke-Command -Session $sendPSSession -ScriptBlock $ScriptBlockCreateDirForResults -ArgumentList ($CommandsDir+"\Sender\ntttcp\udp")
-        Invoke-Command -Session $recvPSSession -ScriptBlock $ScriptBlockCreateDirForResults -ArgumentList ($CommandsDir+"\Receiver\latte")
-        Invoke-Command -Session $sendPSSession -ScriptBlock $ScriptBlockCreateDirForResults -ArgumentList ($CommandsDir+"\Sender\latte")
+        Invoke-Command -Session $recvPSSession -ScriptBlock $ScriptBlockCreateDirForResults -ArgumentList ($CommandsDir+"\Receiver\latte\optimized")
+        Invoke-Command -Session $recvPSSession -ScriptBlock $ScriptBlockCreateDirForResults -ArgumentList ($CommandsDir+"\Receiver\latte\default")
+        Invoke-Command -Session $sendPSSession -ScriptBlock $ScriptBlockCreateDirForResults -ArgumentList ($CommandsDir+"\Sender\latte\optimized")
+        Invoke-Command -Session $sendPSSession -ScriptBlock $ScriptBlockCreateDirForResults -ArgumentList ($CommandsDir+"\Sender\latte\default")
 
         #copy the tool exe to the remote machines
         Copy-Item -Path "$toolpath\$toolexe" -Destination "$CommandsDir\Receiver" -ToSession $recvPSSession


### PR DESCRIPTION
Creating new subdirs : default and optimized, for latte
Fixed ntttcp buflength for non-detail (default) case
Adjusting the testing.config params to match those used by Athena TCP/IP tests

@omarcardona, @Cmaloney-msft