### PR TITLE
Fixing user reported issue [Issue #30]- runPerftool does not handle e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,11 @@ If you would like you use a different configuration, pass in the name of the con
 
 ## Setup
 Before proceeding to run the commands/tests that were generated above, we must enable Powershell Remoting. 
-Don't worry, we have a script that can do all of this for you.
-We also have a cleanup script that we recommend you run after collecting the results (more on that below, in the Cleanup section)
-
 To setup the machine(s), please run the following command on each machine you wish to test (example: Destination and Source machine)
 ```PowerShell 
 SetupTearDown.ps1 -Setup
 ```
+We also have a cleanup script that we recommend you run after collecting the results (more on that below, in the Cleanup section)
 
 ## Running the tool, collecting results
 We are now at the phase where we will run the tests against the Source and Destination Machines and collect results for offline troubleshooting.
@@ -58,7 +56,7 @@ The command to run tests is:
 ProcessCommands -DestIp DestinationMachineIP -SrcIp SourceMachineIP -CommandsDir C:\Temp\MyDirectoryForTesting\msdbg.CurrentMachineName.perftest -SrcIpUserName SrcDomain\SrcUserName -DestIpUserName DestDomain\DestUserName
 ```
 
-You will be prompted for password for both credentials. Don't worry, it's a Secure-string so your password will not be displayed or stored in clear text at any point.
+You will be prompted for password for both credentials. It is a Secure-string so your password will not be displayed or stored in clear text at any point.
 
 ```PowerShell commands
 Import-Module -Force .\runPerftool.psm1
@@ -67,14 +65,14 @@ For further help run
 Get-Help ProcessCommands
 ```
 
-That's it. Now sit back and wait for the script to complete. You should see the zip files from DestinationMachineIp and SourceMachineIP machines under the 
+Once the script is complete, you should see the zip files from DestinationMachineIp and SourceMachineIP machines under the 
 CommandsDir folder you specified (ex: C:\Temp\MyDirectoryForTesting\msdbg.CurrentMachineName.perftest)
 
-At this point you are done! Just don't forget to share the folder contents and please do move on to the Cleanup step below.
+At this point you are done! Don't forget to share the folder contents and run Cleanup step below.
 
 ## Cleanup
-Now that you're done running the relevant tests, we recommend you run the cleanup script to undo the steps that were done in the Setup stage.
-To cleanup the machine(s), please run the following command on each machine you leveraged for testing (Destination and Source machine)
+After finishing running the relevant tests, it is recommended to run the cleanup script to undo the steps that were done in the Setup stage.
+To cleanup the machine(s), run the following command on each machine you leveraged for testing (Destination and Source machine)
 
 ```PowerShell 
 SetupTearDown.ps1 -Cleanup

--- a/latte/latte.Config.json
+++ b/latte/latte.Config.json
@@ -14,7 +14,7 @@
 
     "LatteAzure": 
     {
-        "Iterations"     : 15,
+        "Iterations"     : 20,
         "Protocol"       : ["tcp", "udp"],
         "StartPort"      : 50000,
         "Time"           : 30,

--- a/ntttcp/ntttcp.Config.json
+++ b/ntttcp/ntttcp.Config.json
@@ -29,7 +29,7 @@
             "Options": ""
         },
         "udp" : {
-            "BufferLen"     : [1372, 1472],
+            "BufferLen"     : [1372],
             "Connections"   : [1, 64],
             "OutstandingIo" : null,
             "Options"       : ""
@@ -49,7 +49,7 @@
             "Options"       : ""
         },
         "udp" : {
-            "BufferLen"     : [512, 1372, 1472],
+            "BufferLen"     : [512, 1000, 1372, 1400, 1472],
             "Connections"   : [1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
             "OutstandingIo" : null,
             "Options"       : ""

--- a/runPerftool.psm1
+++ b/runPerftool.psm1
@@ -232,14 +232,16 @@ Function ProcessCommands{
 
     [PSCredential] $recvIPCreds = New-Object System.Management.Automation.PSCredential($DestIpUserName, $DestIpPassword)
 
+    [String] $workingDir = $CommandsDir.TrimEnd("\")
+
     LogWrite "Processing ntttcp commands" $true
-    ProcessToolCommands -Toolname "ntttcp" -RecvComputerName $recvComputerName -RecvComputerCreds $recvIPCreds -SendComputerName $sendComputerName -SendComputerCreds $sendIPCreds -CommandsDir $CommandsDir -Bcleanup $Bcleanup -BZip $ZipResults -TimeoutValueBetweenCommandPairs $TimeoutValueInSeconds -PollTimeInSeconds $PollTimeInSeconds
+    ProcessToolCommands -Toolname "ntttcp" -RecvComputerName $recvComputerName -RecvComputerCreds $recvIPCreds -SendComputerName $sendComputerName -SendComputerCreds $sendIPCreds -CommandsDir $workingDir -Bcleanup $Bcleanup -BZip $ZipResults -TimeoutValueBetweenCommandPairs $TimeoutValueInSeconds -PollTimeInSeconds $PollTimeInSeconds
 
     LogWrite "Processing latte commands" $true
-    ProcessToolCommands -Toolname "latte" -RecvComputerName $recvComputerName -RecvComputerCreds $recvIPCreds -SendComputerName $sendComputerName -SendComputerCreds $sendIPCreds -CommandsDir $CommandsDir -Bcleanup $Bcleanup -BZip $ZipResults -TimeoutValueBetweenCommandPairs $TimeoutValueInSeconds -PollTimeInSeconds $PollTimeInSeconds
+    ProcessToolCommands -Toolname "latte" -RecvComputerName $recvComputerName -RecvComputerCreds $recvIPCreds -SendComputerName $sendComputerName -SendComputerCreds $sendIPCreds -CommandsDir $workingDir -Bcleanup $Bcleanup -BZip $ZipResults -TimeoutValueBetweenCommandPairs $TimeoutValueInSeconds -PollTimeInSeconds $PollTimeInSeconds
 
     LogWrite "ProcessCommands Done!" $true
-    Move-Item -Path $Logfile -Destination "$CommandsDir" -Force -ErrorAction Ignore
+    Move-Item -Path $Logfile -Destination "$workingDir" -Force -ErrorAction Ignore
 
 } # ProcessCommands()
 


### PR DESCRIPTION
…xtraneous trailing '\' for CommandDir

- Fix : Trim the directory variable before using it

Changes to Azure config
- Adding more latte iterations to tackle variance
- Removing 1472 test case for udp. We will stick to 1372 for now

Changes to Detail config for ntttcp
- Adding more bufferlengths for udp [Fix for issue #25 https://github.com/microsoft/NetPerfTest/issues/25]

Other Misc changes:
Made some changes to Readme to be consistent with the readme on Npt-Linux